### PR TITLE
`リストに登録`を開いていた時のクラッシュを修正

### DIFF
--- a/js/script.js
+++ b/js/script.js
@@ -51,6 +51,13 @@ function videoscript() {
 
         //ボタンクリック時
         $("#nicoadButton").on('click', function () {
+            //リストに登録を開いていたら閉じる
+            try {
+                if ($(".AddVideoListPanelContainer-header")[0].textContent == "リストに登録") {
+                    $(".MylistButton").click();
+                }
+            } catch (err) { }
+
             $('.MainContainer-floatingPanel').attr('id', 'PanelContainer');
             $('#PanelContainer').html('<div class="FloatingPanelContainer is-visible"><div class="AddVideoListPanelContainer"><div class="AddVideoListPanelContainer-header">ニコニ広告ex. <button type="button" class="ActionButton CloseButton AddVideoListPanelContainer-header-closeButton" id="exclose"><div class="CloseButton-inner"><svg viewBox="0 0 100 100" fill-rule="evenodd" clip-rule="evenodd" stroke-linejoin="round" stroke-miterlimit="1.4"><path d="M50 32.8L81.6 1.2a4.1 4.1 0 0 1 5.8 0l11.4 11.4a4.1 4.1 0 0 1 0 5.9L67.2 50l31.6 31.6a4.1 4.1 0 0 1 0 5.8L87.4 98.8a4.1 4.1 0 0 1-5.9 0L50 67.2 18.4 98.8a4.1 4.1 0 0 1-5.8 0L1.2 87.4a4.1 4.1 0 0 1 0-5.9L32.8 50 1.2 18.4a4.1 4.1 0 0 1 0-5.8L12.6 1.2a4.1 4.1 0 0 1 5.9 0L50 32.8z"></path></svg></div></button></div><div class="AddVideoListPanelContainer-content""><div class="AddingMylistPanel" style="height:100%;"><iframe id="nicoadex-iframe" src="hoge" style="border:none; width:100%; height:100%;"></iframe></div></div></div></div>');
 


### PR DESCRIPTION
## 不具合の詳細
`リストに登録` --> `ニコニ広告ex.` --> `リストに登録` の順にクリックするとプレイヤーがクラッシュ(リロード)する。

![nicoadex_list_crash](https://user-images.githubusercontent.com/29059223/128038950-7cbee953-5eda-4c09-8981-d3ccb72e8df2.gif)

## 変更点
- `ニコニ広告ex.`ボタンクリック時に`リストに登録`を開いていたら閉じる処理を追加。