### PR TITLE
広告ボタンのチェックとリトライ処理を変更

### DIFF
--- a/js/script.js
+++ b/js/script.js
@@ -3,6 +3,11 @@ let manifestData = chrome.runtime.getManifest();
 let ex_version = manifestData.version + "";
 console.log("ニコニ広告ex.: v" + ex_version);
 
+function isDefaultButtonExist() {
+    const btnDefault = document.querySelector('[aria-label="ニコニ広告"], [data-title="ニコニ広告する"]')
+    return btnDefault != null
+}
+
 
 //ID取得
 window.onload = function getID() {
@@ -77,26 +82,16 @@ function videoscript() {
         });
     }
 
-    function v_checkadex() {
-        if (document.getElementById("nicoadButton")) {
-            console.log("ニコニ広告ex.: 動作中です");
-        } else {
-            main_video();
-        }
-    }
-
     function video_first() {
         //初回～
-        $('[data-title="ニコニ広告する"]').attr('id', 'nicoadButton');
-        if (document.getElementById("nicoadButton")) {
+        if (isDefaultButtonExist()) {
             main_video();
         } else {
-            console.log("ニコニ広告ex.: ニコニ広告ボタンを取得できませんでした。再実行します。");
+            console.log("ニコニ広告ex.: ニコニ広告ボタンを取得できませんでした。");
         }
     }
 
     video_first();
-    setInterval(v_checkadex, 2500);
 }
 
 
@@ -224,20 +219,25 @@ function livescript() {
             $('#nicoadex_iframePanel_header').remove();
         });
     }
-    var checkadex = function checkad() {
-        if (document.getElementById("nicoadButton")) {
+
+    //初回～
+    async function live_first() {
+        // ボタンが遅延上書きされる場合があるので、変更を検知して上書きする。
+        // 上書きによって消えない親要素を監視する。
+        const target = document.querySelector('[class*="ichiba-counter-section"]')
+        const observer = new MutationObserver(() => {
+            if (isDefaultButtonExist()) {
+                live_main()
+            }
+        })
+        observer.observe(target, { attributes: true, childList: true, subtree: true })
+
+        if (isDefaultButtonExist()) {
+            live_main()
         } else {
-            live_main();
+            console.log("ニコニ広告ex.: ニコニ広告ボタンを取得できませんでした。");
         }
     }
 
-    //初回～
-    $('[aria-label="ニコニ広告"]').attr('id', 'nicoadButton');
-    if (document.getElementById("nicoadButton")) {
-        live_main();
-    } else {
-        error_notAD();
-        console.log("ニコニ広告ex.: ニコニ広告ボタンを取得できませんでした。");
-    }
-    setInterval(checkadex, 2000);
+    live_first();
 }

--- a/js/script.js
+++ b/js/script.js
@@ -8,7 +8,7 @@ async function sleep(msec) {
 }
 
 function isDefaultButtonExist() {
-    const btnDefault = document.querySelector('[aria-label="ニコニ広告"], [data-title="ニコニ広告"]')
+    const btnDefault = document.querySelector('[aria-label="ニコニ広告"], [data-title="ニコニ広告する"]')
     return btnDefault != null
 }
 

--- a/js/script.js
+++ b/js/script.js
@@ -3,8 +3,12 @@ let manifestData = chrome.runtime.getManifest();
 let ex_version = manifestData.version + "";
 console.log("ニコニ広告ex.: v" + ex_version);
 
+async function sleep(msec) {
+    return new Promise(resolve => { setTimeout(() => { resolve() }, msec) })
+}
+
 function isDefaultButtonExist() {
-    const btnDefault = document.querySelector('[aria-label="ニコニ広告"], [data-title="ニコニ広告する"]')
+    const btnDefault = document.querySelector('[aria-label="ニコニ広告"], [data-title="ニコニ広告"]')
     return btnDefault != null
 }
 
@@ -82,13 +86,19 @@ function videoscript() {
         });
     }
 
-    function video_first() {
+    async function video_first() {
         //初回～
-        if (isDefaultButtonExist()) {
-            main_video();
-        } else {
-            console.log("ニコニ広告ex.: ニコニ広告ボタンを取得できませんでした。");
+        const maxRetry = 10
+        const interval = 1000
+        for (let i = 0; i <= maxRetry; i++) {
+            if (isDefaultButtonExist()) {
+                main_video();
+                return;
+            } else if (i <= maxRetry - 1) {
+                await sleep(interval);
+            }
         }
+        console.log("ニコニ広告ex.: ニコニ広告ボタンを取得できませんでした。");
     }
 
     video_first();


### PR DESCRIPTION
## 変更を行う理由
- デフォルトのボタンが存在していなくても、それぞれのボタン上書き処理が実行されていた。
- 上書きに成功した場合でも`setInterval`でデバッグログが流れていて、色々と妨げになる。

## 変更点
### 動画
- `setInterval`によるチェックを削除。
- #6 を考慮して、デフォルトのボタンが存在したら上書き処理を実行し、存在しなかったら一定時間後にリトライするようにした。（とりあえず1秒間隔・10回までとした）

### 生放送
- `setInterval`によるチェックを削除。
- ゲーム等によってボタンが遅延上書きされる場合があるので、`MutationObserver`を使ってボタンの親要素が変更されたら、ボタンの上書きを試行するように変更。
- ボタンが見つからなかった場合のスナックバーによるエラー表示は、classの変更により使えない状態なのでスキップしてます。